### PR TITLE
minor fixes & improvements

### DIFF
--- a/BonfireAuth/src/main/java/sh/sit/bonfire/auth/ApolloController.kt
+++ b/BonfireAuth/src/main/java/sh/sit/bonfire/auth/ApolloController.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.cache.normalized.api.*
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
+import com.dzen.campfire.api.API
 import com.sup.dev.android.app.SupAndroid
 import com.sup.dev.android.libs.image_loader.ImageLoader
 import com.sup.dev.android.libs.image_loader.ImageLoaderRef
@@ -19,7 +20,7 @@ import sh.sit.schema.pagination.Pagination
 object ApolloController {
     @OptIn(ApolloExperimental::class)
     val apolloClient: ApolloClient = ApolloClient.Builder()
-        .serverUrl("https://api.bonfire.moe")
+        .serverUrl(API.MELIOR_ROOT)
         .httpEngine(DefaultHttpEngine(
             OkHttpController.getClient(SupAndroid.appContext!!) {
                 addInterceptor(AuthInterceptor())

--- a/Campfire/build.gradle
+++ b/Campfire/build.gradle
@@ -8,26 +8,48 @@ apply plugin: 'com.mikepenz.aboutlibraries.plugin'
 android {
     compileSdk 36
 
+    def localPropertiesFile = rootProject.file('local.properties')
+    def localProperties = new Properties()
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.withInputStream { stream -> localProperties.load(stream) }
+    }
+
+    def posthogApiKey = localProperties.getProperty("POSTHOG_API_KEY", POSTHOG_API_KEY)
+    def host = localProperties.getProperty("HOST", HOST)
+    def serverPosthog = localProperties.getProperty("SERVER_POSTHOG", SERVER_POSTHOG)
+    def serverRoot = localProperties.getProperty("SERVER_ROOT", SERVER_ROOT)
+    def serverMelior = localProperties.getProperty("SERVER_MELIOR", SERVER_MELIOR)
+    def serverS3 = localProperties.getProperty("SERVER_S3", SERVER_S3)
+    def appId = localProperties.getProperty("APP_ID", APP_ID)
+    def appName = localProperties.getProperty("APP_NAME", APP_NAME)
+
     defaultConfig {
         minSdkVersion 23
         targetSdk 36
         versionCode 4_12_02
         versionName "4.12.2"
-        applicationId "sh.sit.bonfire"
+        applicationId appId
 
-        buildConfigField "String", "POSTHOG_API_KEY", "\"$POSTHOG_API_KEY\""
-        buildConfigField "String", "POSTHOG_HOST", "\"$POSTHOG_HOST\""
+        buildConfigField "String", "POSTHOG_API_KEY", "\"$posthogApiKey\""
+
+        buildConfigField "String", "HOST", "\"$host\""
+        buildConfigField "String", "SERVER_POSTHOG", "\"$serverPosthog\""
+        buildConfigField "String", "SERVER_ROOT", "\"$serverRoot\""
+        buildConfigField "String", "SERVER_MELIOR", "\"$serverMelior\""
+        buildConfigField "String", "SERVER_S3", "\"$serverS3\""
     }
 
     buildTypes {
         release {
-            manifestPlaceholders = [crashlyticsEnabled: false]
+            resValue "string", "app_name", appName
+            manifestPlaceholders = [crashlyticsEnabled: false, usesCleartextTraffic: false, host: HOST]
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {
-            manifestPlaceholders = [crashlyticsEnabled: false]
+            resValue "string", "app_name", appName
+            manifestPlaceholders = [crashlyticsEnabled: false, usesCleartextTraffic: true, host: HOST]
             applicationIdSuffix ".debug"
         }
     }

--- a/Campfire/src/debug/AndroidManifest.xml
+++ b/Campfire/src/debug/AndroidManifest.xml
@@ -1,5 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-    <application
-        android:networkSecurityConfig="@xml/network_security_config"
-        tools:targetApi="n" />
-</manifest>

--- a/Campfire/src/debug/res/xml/network_security_config.xml
+++ b/Campfire/src/debug/res/xml/network_security_config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">192.168.1.114</domain>
-    </domain-config>
-</network-security-config>

--- a/Campfire/src/main/AndroidManifest.xml
+++ b/Campfire/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/CampfireSplash"
-        android:largeHeap="true">
+        android:largeHeap="true"
+        android:usesCleartextTraffic="${usesCleartextTraffic}">
 
         <activity
             android:name="com.dzen.campfire.app.AppActivity"
@@ -39,7 +40,7 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="https" />
-                <data android:host="bonfire.moe" />
+                <data android:host="${host}" />
                 <data android:pathPrefix="/r" />
             </intent-filter>
 

--- a/Campfire/src/main/java/com/dzen/campfire/app/App.kt
+++ b/Campfire/src/main/java/com/dzen/campfire/app/App.kt
@@ -49,6 +49,11 @@ class App : Application() {
 
         FirebaseApp.initializeApp(applicationContext)
 
+        API.SERV_ROOT = BuildConfig.SERVER_ROOT
+        API.MELIOR_ROOT = BuildConfig.SERVER_MELIOR
+        API.S3_ROOT = BuildConfig.SERVER_S3
+        API.DOMEN = "https://${BuildConfig.HOST}/r/"
+
         SupAndroid.init(applicationContext, BuildConfig.APPLICATION_ID, AppActivity::class.java)
         SupAndroid.imgErrorGone = ImageLoader.load(ApiResources.IMAGE_BACKGROUND_17).noHolder()
         SupAndroid.imgErrorNetwork = ImageLoader.load(ApiResources.IMAGE_BACKGROUND_20).noHolder()
@@ -56,7 +61,7 @@ class App : Application() {
 
         PostHogAndroid.setup(this, PostHogAndroidConfig(
             apiKey = BuildConfig.POSTHOG_API_KEY,
-            host = BuildConfig.POSTHOG_HOST,
+            host = BuildConfig.SERVER_POSTHOG,
         ).apply {
             optOut = !canSendAnalytics()
         })

--- a/Campfire/src/main/res/values/strings.xml
+++ b/Campfire/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name" translatable="false">Bonfire</string>
 </resources>

--- a/CampfireApi/src/main/java/com/dzen/campfire/api/API.kt
+++ b/CampfireApi/src/main/java/com/dzen/campfire/api/API.kt
@@ -831,6 +831,7 @@ class API(
         const val HISTORY_PUBLICATION_TYPE_ADMIN_REMOVE_MEDIA = 29L
         const val HISTORY_PUBLICATION_TYPE_SET_NSFW = 30L
         const val HISTORY_PUBLICATION_TYPE_ADMIN_SET_NSFW = 31L
+        const val HISTORY_PUBLICATION_TYPE_PENDING = 32L
 
         //
         //  Post

--- a/CampfireApi/src/main/java/com/dzen/campfire/api/API.kt
+++ b/CampfireApi/src/main/java/com/dzen/campfire/api/API.kt
@@ -22,12 +22,12 @@ class API(
         const val PORT_SERV_JL_V1 = 7070
         const val PORT_SERV_JL = 7071
 
-        const val S3_ROOT = "https://proxy.bonfire.moe/bonfire"
-        const val MELIOR_ROOT = "https://proxy.bonfire.moe/api"
-        const val SERV_ROOT = "https://proxy.bonfire.moe/cf2"
+        lateinit var SERV_ROOT: String
+        lateinit var MELIOR_ROOT: String
+        lateinit var S3_ROOT: String
         const val TL_ROOT = "https://proxy.bonfire.moe"
 
-        const val DOMEN = "https://bonfire.moe/r/"
+        lateinit var DOMEN: String
         const val DOMEN_DL = "bf://link/"
         const val VERSION = "3.1"
         const val SUPPORTED_VERSION = "2.0"
@@ -67,6 +67,7 @@ class API(
         val LINK_CONF = Link("conf")
         val LINK_FANDOM = Link("fandom")
         val LINK_PROFILE_ID = Link("profileid")
+        val LINK_PROFILE_NAME = Link("profile")
         val LINK_MODERATION = Link("moderation")
         val LINK_STICKER = Link("sticker")
         val LINK_STICKERS_PACK = Link("stickers")
@@ -125,7 +126,6 @@ class API(
         const val LINK_TAG_PROFILE_NAME = "profile"
         const val LINK_SHORT_PROFILE = "@"
         const val LINK_SHORT_PROFILE_SECOND = "#"
-        const val LINK_PROFILE_NAME = "$DOMEN$LINK_TAG_PROFILE_NAME-"
 
         const val ERROR_GONE = "ERROR_GONE"
         const val ERROR_BAD_COMMENT = "ERROR_BAD_COMMENT"
@@ -1114,20 +1114,6 @@ class API(
         const val QUEST_PART_TYPE_CONDITION = 2L
         const val QUEST_PART_TYPE_ACTION = 3L
         const val QUEST_PART_TYPE_UNKNOWN = 100L
-
-        //
-        //  Reactions
-        //
-
-        val REACTIONS = arrayOf(
-                ApiResources.EMOJI_1,
-                ApiResources.EMOJI_2,
-                ApiResources.EMOJI_3,
-                ApiResources.EMOJI_4,
-                ApiResources.EMOJI_5,
-                ApiResources.EMOJI_6,
-                ApiResources.EMOJI_7
-        )
 
         //
         //  Language

--- a/CampfireApi/src/main/java/com/dzen/campfire/api/API_TRANSLATE.kt
+++ b/CampfireApi/src/main/java/com/dzen/campfire/api/API_TRANSLATE.kt
@@ -1093,6 +1093,7 @@ object API_TRANSLATE {
     var history_admin_close_no = 0L
     var history_set_nsfw_true = 0L
     var history_set_nsfw_false = 0L
+    var history_pending = 0L
 
     var campfire_hello_annotation = 0L
     var campfire_hello_1 = 0L

--- a/CampfireApi/src/main/java/com/dzen/campfire/api/ApiResources.kt
+++ b/CampfireApi/src/main/java/com/dzen/campfire/api/ApiResources.kt
@@ -471,4 +471,14 @@ object ApiResources {
         QUEST_NEW_YEAR_9,
         QUEST_NEW_YEAR_10
     )
+
+    val REACTIONS = arrayOf(
+        EMOJI_1,
+        EMOJI_2,
+        EMOJI_3,
+        EMOJI_4,
+        EMOJI_5,
+        EMOJI_6,
+        EMOJI_7
+    )
 }

--- a/CampfireApi/src/main/java/com/dzen/campfire/api/models/publications/history/History.kt
+++ b/CampfireApi/src/main/java/com/dzen/campfire/api/models/publications/history/History.kt
@@ -82,6 +82,7 @@ abstract class History : JsonParsable, ImageHolder {
                 API.HISTORY_PUBLICATION_TYPE_ADMIN_REMOVE_MEDIA -> HistoryAdminRemoveMedia()
                 API.HISTORY_PUBLICATION_TYPE_SET_NSFW -> HistorySetNsfw()
                 API.HISTORY_PUBLICATION_TYPE_ADMIN_SET_NSFW -> HistoryAdminSetNsfw()
+                API.HISTORY_PUBLICATION_TYPE_PENDING -> HistoryPending()
                 else -> HistoryUnknown()
             }
 

--- a/CampfireApi/src/main/java/com/dzen/campfire/api/models/publications/history/HistoryPending.kt
+++ b/CampfireApi/src/main/java/com/dzen/campfire/api/models/publications/history/HistoryPending.kt
@@ -1,0 +1,26 @@
+package com.dzen.campfire.api.models.publications.history
+
+import com.dzen.campfire.api.API
+import com.sup.dev.java.libs.json.Json
+
+class HistoryPending : History {
+    var pendingTime = 0L
+
+    override fun getType() = API.HISTORY_PUBLICATION_TYPE_PENDING
+
+    override fun json(inp: Boolean, json: Json): Json {
+        pendingTime = json.m(inp, "pendingTime", pendingTime)
+        return super.json(inp, json)
+    }
+
+    constructor()
+
+    constructor(
+        userId: Long,
+        userImageId: Long,
+        userName: String,
+        pendingTime: Long
+    ) : super(userId, userImageId, userName, "") {
+        this.pendingTime = pendingTime
+    }
+}

--- a/CampfireApi/src/main/java/com/dzen/campfire/api/requests/publications/RPublicationsReportsGetAll.kt
+++ b/CampfireApi/src/main/java/com/dzen/campfire/api/requests/publications/RPublicationsReportsGetAll.kt
@@ -1,5 +1,6 @@
 package com.dzen.campfire.api.requests.publications
 
+import com.dzen.campfire.api.models.images.ImageHolderReceiver
 import com.dzen.campfire.api.models.publications.PublicationReport
 import com.dzen.campfire.api.tools.client.Request
 import com.sup.dev.java.libs.json.Json
@@ -42,6 +43,11 @@ open class RPublicationsReportsGetAll(
             reports = json.m(inp, "reports", reports, Array<PublicationReport>::class)
         }
 
+        override fun fillImageRefs(receiver: ImageHolderReceiver) {
+            for (report in reports) {
+                report.account.fillImageRefs(receiver)
+            }
+        }
     }
 
 }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/Reactions.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/Reactions.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.dzen.campfire.api.API
 import com.dzen.campfire.api.ApiResources
 import com.dzen.campfire.api.models.publications.Publication
 import com.dzen.campfire.api.requests.publications.RPublicationsReactionAdd
@@ -55,9 +54,9 @@ fun PublicationReactions(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
     ) {
-        for (reactionIndex in API.REACTIONS.indices.map { it.toLong() }) {
+        for (reactionIndex in ApiResources.REACTIONS.indices.map { it.toLong() }) {
             val reactionCount = data.counts[reactionIndex] ?: 0
-            val image = API.REACTIONS.getOrNull(reactionIndex.toInt()) ?: ApiResources.EMOJI_5
+            val image = ApiResources.REACTIONS.getOrNull(reactionIndex.toInt()) ?: ApiResources.EMOJI_5
 
             val windowOffset = remember { mutableStateOf<Offset?>(null) }
 

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/comment/CommentHeader.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/comment/CommentHeader.kt
@@ -1,5 +1,6 @@
 package com.sayzen.campfiresdk.compose.publication.comment
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.MaterialTheme
@@ -16,6 +17,7 @@ import com.sayzen.campfiresdk.R
 import com.sayzen.campfiresdk.screens.account.profile.SProfile
 import com.sayzen.campfiresdk.screens.fandoms.view.SFandom
 import com.sup.dev.android.libs.screens.navigator.Navigator
+import com.sup.dev.android.tools.ToolsToast
 import com.sup.dev.java.tools.ToolsDate
 
 @Composable
@@ -55,7 +57,11 @@ internal fun CommentHeader(
             style = MaterialTheme.typography.bodyLarge,
             overflow = TextOverflow.Ellipsis,
             softWrap = false,
-            modifier = Modifier.alpha(0.6f)
+            modifier = Modifier
+                .alpha(0.6f)
+                .clickable {
+                    ToolsToast.show(ToolsDate.dateToStringFull(comment.dateCreate))
+                }
         )
     }
 }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/post/PostHeader.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/post/PostHeader.kt
@@ -131,7 +131,7 @@ internal fun PostHeader(post: PublicationPost) {
                     modifier = Modifier
                         .then(if (overflowsWidth) Modifier.weight(1f, fill = false) else Modifier)
                         .clickable {
-                            ToolsToast.show(ToolsDate.dateToString(creationTimestamp))
+                            ToolsToast.show(ToolsDate.dateToStringFull(creationTimestamp))
                         },
                 )
             }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/post/pages/activity/UserActivityPage.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/compose/publication/post/pages/activity/UserActivityPage.kt
@@ -128,7 +128,7 @@ private fun UserActivityCountdown(stopAt: Long) {
     val remaining = stopAt - currentTime.longValue
 
     Text(
-        text = ToolsDate.dayTimeToString_Ms_HH_MM_SS(remaining),
+        text = ToolsDate.timeToString(remaining),
         style = MaterialTheme.typography.bodyMedium,
         softWrap = false,
     )

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerComment.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerComment.kt
@@ -7,6 +7,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import com.dzen.campfire.api.API
 import com.dzen.campfire.api.API_TRANSLATE
+import com.dzen.campfire.api.ApiResources
 import com.dzen.campfire.api.models.publications.PublicationComment
 import com.dzen.campfire.api.requests.publications.RPublicationsReactionAdd
 import com.dzen.campfire.api.requests.publications.RPublicationsReactionRemove
@@ -95,12 +96,12 @@ object ControllerComment {
 
 
         val p = ToolsView.dpToPx(4).toInt()
-        for (i in API.REACTIONS.indices) {
+        for (i in ApiResources.REACTIONS.indices) {
             val v: ViewIcon = ToolsView.inflate(vMenuReactionsLinear, R.layout.z_icon_18)
             v.setPadding(p, p, p, p)
             v.setOnClickListener { sendReaction(publication, i.toLong()); w?.hide(); }
             vMenuReactionsLinear.addView(v)
-            ImageLoader.load(API.REACTIONS[i]).into(v)
+            ImageLoader.load(ApiResources.REACTIONS[i]).into(v)
         }
     }
 

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerEffects.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerEffects.kt
@@ -128,7 +128,7 @@ object ControllerEffects {
                 .setOnEnter(t(API_TRANSLATE.app_choose)) { _, date ->
                     SplashChooseTime()
                             .setOnEnter(t(API_TRANSLATE.app_choose)) { _, h, m ->
-                                val endDate = ToolsDate.getStartOfDay_GlobalTimeZone(date) + (h * 60L * 60 * 1000) + (m * 60L * 1000)
+                                val endDate = ToolsDate.getStartOfDay(date) + (h * 60L * 60 * 1000) + (m * 60L * 1000)
                                 if (endDate < System.currentTimeMillis()) {
                                     ToolsToast.show(t(API_TRANSLATE.effect_error_time))
                                     return@setOnEnter

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerFandoms.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerFandoms.kt
@@ -148,7 +148,6 @@ object ControllerFandoms {
                             .setOnCancel(t(API_TRANSLATE.app_cancel))
                             .setMin(API.MODERATION_COMMENT_MIN_L)
                             .setMax(API.MODERATION_COMMENT_MAX_L)
-                            .addChecker(t(API_TRANSLATE.error_use_english)) { ToolsText.isOnly(it, API.ENGLISH) }
                             .setOnEnter(t(API_TRANSLATE.app_change)) { w, comment ->
                                 ApiRequestsSupporter.executeEnabled(w, RFandomsAdminChangeCategory(xFandom.getId(), c.index, comment)) {
                                     EventBus.post(EventFandomCategoryChanged(xFandom.getId(), c.index))
@@ -180,7 +179,6 @@ object ControllerFandoms {
                 .setOnCancel(t(API_TRANSLATE.app_cancel))
                 .setMin(API.MODERATION_COMMENT_MIN_L)
                 .setMax(API.MODERATION_COMMENT_MAX_L)
-                .addChecker(t(API_TRANSLATE.error_use_english)) { ToolsText.isOnly(it, API.ENGLISH) }
                 .setOnEnter(t(API_TRANSLATE.app_remove)) { _, comment ->
                     ApiRequestsSupporter.executeEnabledConfirm(t(API_TRANSLATE.fandom_remove_confirm), t(API_TRANSLATE.app_remove), RFandomsAdminRemove(xFandom.getId(), comment)) {
                         EventBus.post(EventFandomRemove(xFandom.getId()))
@@ -208,7 +206,6 @@ object ControllerFandoms {
                 .setMin_2(API.MODERATION_COMMENT_MIN_L)
                 .setMax_2(API.MODERATION_COMMENT_MAX_L)
                 .setHint_2(t(API_TRANSLATE.comments_hint))
-                .addChecker_2(t(API_TRANSLATE.error_use_english)) { ToolsText.isOnly(it, API.ENGLISH) }
                 .setOnEnter(t(API_TRANSLATE.app_rename)) { _, name, comment ->
                     ApiRequestsSupporter.executeEnabledConfirm(t(API_TRANSLATE.fandoms_menu_rename_confirm), t(API_TRANSLATE.fandoms_menu_rename), RFandomsAdminChangeName(xFandom.getId(), name, comment)) {
                         EventBus.post(EventFandomChanged(xFandom.getId(), name))

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerLinks.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/controllers/ControllerLinks.kt
@@ -263,7 +263,7 @@ object ControllerLinks {
         }
     }
 
-    fun linkToAccount(name: String) = API.LINK_PROFILE_NAME + name
+    fun linkToAccount(name: String) = API.LINK_PROFILE_NAME.asWeb() + name
     fun linkToAccount(id: Long) = API.LINK_PROFILE_ID.asWeb() + id
     fun linkToFandom(fandomId: Long) = API.LINK_FANDOM.asWeb() + fandomId
     fun linkToFandom(fandomId: Long, languageId: Long) = API.LINK_FANDOM.asWeb() + fandomId + "_" + languageId
@@ -303,7 +303,7 @@ object ControllerLinks {
     fun makeLinkable(vText: ViewText) {
         // fixme: don't do this maybe?
         vText.text = vText.text.toString()
-            .replace(API.LINK_PROFILE_NAME, "@")
+            .replace(API.LINK_PROFILE_NAME.asWeb(), "@")
             .replace(API.DOMEN, "@")
         ControllerApi.makeTextHtml(vText)
         LinkifyCompat.addLinks(vText, Linkify.WEB_URLS)
@@ -319,7 +319,7 @@ object ControllerLinks {
             API.DOMEN,
             null,
             { link, start, end -> isCorrectLink(link.subSequence(start, end)) },
-            { match, _ -> "https://bonfire.moe/r/${match.group(1)}" }
+            { match, _ -> API.DOMEN + match.group(1) }
         )
     }
 

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/CardChatMessage.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/CardChatMessage.kt
@@ -10,6 +10,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import com.dzen.campfire.api.API
 import com.dzen.campfire.api.API_TRANSLATE
+import com.dzen.campfire.api.ApiResources
 import com.dzen.campfire.api.models.chat.ChatTag
 import com.dzen.campfire.api.models.notifications.chat.NotificationChatMessageChange
 import com.dzen.campfire.api.models.notifications.chat.NotificationChatMessageRemove
@@ -694,9 +695,9 @@ open class CardChatMessage constructor(
                 );true
             }
 
-            val index = if (i.reactionIndex > -1 && i.reactionIndex < API.REACTIONS.size) i.reactionIndex.toInt() else 0
+            val index = if (i.reactionIndex > -1 && i.reactionIndex < ApiResources.REACTIONS.size) i.reactionIndex.toInt() else 0
             v.setIcon(R.color.focus)
-            ImageLoader.load(API.REACTIONS[index]).intoBitmap { v.setIcon(it) }
+            ImageLoader.load(ApiResources.REACTIONS[index]).intoBitmap { v.setIcon(it) }
         }
 
         (vReactions.layoutParams as ViewGroup.MarginLayoutParams).topMargin =
@@ -912,12 +913,12 @@ open class CardChatMessage constructor(
             .asPopupShow(targetView, x, y)
 
         val p = ToolsView.dpToPx(4).toInt()
-        for (i in API.REACTIONS.indices) {
+        for (i in ApiResources.REACTIONS.indices) {
             val v: ViewIcon = ToolsView.inflate(vMenuReactionsLinear, R.layout.z_icon_18)
             v.setPadding(p, p, p, p)
             v.setOnClickListener { sendReaction(i.toLong()); w?.hide(); }
             vMenuReactionsLinear.addView(v)
-            ImageLoader.load(API.REACTIONS[i]).into(v)
+            ImageLoader.load(ApiResources.REACTIONS[i]).into(v)
         }
     }
 

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/CardComment.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/CardComment.kt
@@ -8,6 +8,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import com.dzen.campfire.api.API
 import com.dzen.campfire.api.API_TRANSLATE
+import com.dzen.campfire.api.ApiResources
 import com.dzen.campfire.api.models.notifications.comments.NotificationComment
 import com.dzen.campfire.api.models.notifications.comments.NotificationCommentAnswer
 import com.dzen.campfire.api.models.notifications.publications.NotificationMention
@@ -420,9 +421,9 @@ open class CardComment(
                 );true
             }
 
-            val index = if (i.reactionIndex > -1 && i.reactionIndex < API.REACTIONS.size) i.reactionIndex.toInt() else 0
+            val index = if (i.reactionIndex > -1 && i.reactionIndex < ApiResources.REACTIONS.size) i.reactionIndex.toInt() else 0
             v.setIcon(R.color.focus)
-            ImageLoader.load(API.REACTIONS[index]).intoBitmap { v.setIcon(it) }
+            ImageLoader.load(ApiResources.REACTIONS[index]).intoBitmap { v.setIcon(it) }
         }
 
         (vReactions.layoutParams as ViewGroup.MarginLayoutParams).topMargin =

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/events/CardPublicationEventAdmin.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/events/CardPublicationEventAdmin.kt
@@ -59,14 +59,14 @@ class CardPublicationEventAdmin(
         when (e) {
 
             is ApiEventAdminBan -> {
-                text = tCap(API_TRANSLATE.publication_event_blocked_app_admin, tSexCap(CampfireConstants.RED, e.ownerAccountSex, API_TRANSLATE.he_blocked, API_TRANSLATE.she_blocked), ControllerLinks.linkToAccount(e.targetAccountName), ToolsDate.dateToStringFull(e.blockDate))
+                text = tCap(API_TRANSLATE.publication_event_blocked_app_admin, tSexCap(CampfireConstants.RED, e.ownerAccountSex, API_TRANSLATE.he_blocked, API_TRANSLATE.she_blocked), ControllerLinks.linkToAccount(e.targetAccountName), ToolsDate.dateToString(e.blockDate, false))
                 view.setOnClickListener { SProfile.instance(e.targetAccountId, Navigator.TO) }
             }
             is ApiEventAdminBlockPublication -> {
                 val publicationName = ControllerPublications.getName(e.publicationType)
                 text = tCap(API_TRANSLATE.publication_event_admin_blocked_publication, tSexCap(CampfireConstants.RED, e.ownerAccountSex, API_TRANSLATE.he_blocked, API_TRANSLATE.she_blocked), publicationName, ControllerLinks.linkToAccount(e.targetAccountName))
-                if (e.blockAccountDate > 0 && e.blockedInApp && e.blockFandomId < 1) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date, ToolsDate.dateToStringFull(e.blockAccountDate))
-                if (e.blockAccountDate > 0 && !e.blockedInApp && e.blockFandomId > 0) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date_fandom, ToolsDate.dateToStringFull(e.blockAccountDate), "${e.blockFandomName}")
+                if (e.blockAccountDate > 0 && e.blockedInApp && e.blockFandomId < 1) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date, ToolsDate.dateToString(e.blockAccountDate, false))
+                if (e.blockAccountDate > 0 && !e.blockedInApp && e.blockFandomId > 0) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date_fandom, ToolsDate.dateToString(e.blockAccountDate, false), "${e.blockFandomName}")
                 if (e.warned) text += "\n${t(API_TRANSLATE.publication_event_account_block_warn)}"
                 if (e.lastPublicationsBlocked) text += "\n${t(API_TRANSLATE.publication_event_account_block_last_publications)}"
                 view.setOnClickListener { SProfile.instance(e.targetAccountId, Navigator.TO) }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/events/CardPublicationEventUser.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/events/CardPublicationEventUser.kt
@@ -86,14 +86,14 @@ class CardPublicationEventUser(
                 view.setOnClickListener { ControllerCampfireSDK.onToAchievementClicked(publication.creator.id, publication.creator.name, API.ACHI_QUESTS.index, false, Navigator.TO) }
             }
             is ApiEventUserAdminBaned -> {
-                text = tCap(API_TRANSLATE.publication_event_block_app, "{D32F2F ${ToolsResources.sex(e.adminAccountSex, t(API_TRANSLATE.he_baned), t(API_TRANSLATE.she_baned)).capitalize()}}", ToolsDate.dateToStringFull(e.blockDate), ControllerLinks.linkToAccount(e.adminAccountName))
+                text = tCap(API_TRANSLATE.publication_event_block_app, "{D32F2F ${ToolsResources.sex(e.adminAccountSex, t(API_TRANSLATE.he_baned), t(API_TRANSLATE.she_baned)).capitalize()}}", ToolsDate.dateToString(e.blockDate, false), ControllerLinks.linkToAccount(e.adminAccountName))
                 view.setOnClickListener { SProfile.instance(e.ownerAccountId, Navigator.TO) }
             }
             is ApiEventUserAdminPublicationBlocked -> {
                 val publicationName = ControllerPublications.getName(e.publicationType)
                 text = tCap(API_TRANSLATE.publication_event_block_publication, ControllerLinks.linkToAccount(e.adminAccountName), tSex(CampfireConstants.RED, e.adminAccountSex, API_TRANSLATE.he_blocked, API_TRANSLATE.she_blocked), publicationName)
-                if (e.blockedInApp && e.blockAccountDate > 0) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date, ToolsDate.dateToStringFull(e.blockAccountDate))
-                if (!e.blockedInApp && e.blockAccountDate > 0) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date_fandom, ToolsDate.dateToStringFull(e.blockAccountDate), "${e.blockFandomName}")
+                if (e.blockedInApp && e.blockAccountDate > 0) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date, ToolsDate.dateToString(e.blockAccountDate, false))
+                if (!e.blockedInApp && e.blockAccountDate > 0) text += "\n" + t(API_TRANSLATE.publication_event_account_block_date_fandom, ToolsDate.dateToString(e.blockAccountDate, false), "${e.blockFandomName}")
                 if (e.warned) text += "\n${t(API_TRANSLATE.publication_event_account_block_warn)}"
                 if (e.lastPublicationsBlocked) text += "\n${t(API_TRANSLATE.publication_event_account_block_last_publications)}"
                 view.setOnClickListener {

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/history/CardHistoryPublication.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/history/CardHistoryPublication.kt
@@ -78,6 +78,7 @@ class CardHistoryPublication(
                     vAvatar.setSubtitle(t(API_TRANSLATE.history_set_nsfw_false))
                 }
             }
+            is HistoryPending -> vAvatar.setSubtitle(t(API_TRANSLATE.history_pending, ToolsDate.dateToString(history.pendingTime)))
         }
 
         if (history.comment.isNotEmpty()) vAvatar.setSubtitle(vAvatar.getSubTitle() + "\n" + t(API_TRANSLATE.app_comment) + ": " + history.comment)

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/post_pages/CardPageUserActivity.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/models/cards/post_pages/CardPageUserActivity.kt
@@ -140,7 +140,7 @@ class CardPageUserActivity(
             vPageTimer.setTextColor(colorGreen)
         } else {
             vPageUser.visibility = View.VISIBLE
-            vPageTimer.text = ToolsDate.dayTimeToString_Ms_HH_MM_SS(date - System.currentTimeMillis())
+            vPageTimer.text = ToolsDate.timeToString(date - System.currentTimeMillis())
             vPageTimer.setTextColor(colorWhite)
         }
     }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/activities/user_activities/CardUserActivity.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/activities/user_activities/CardUserActivity.kt
@@ -160,7 +160,7 @@ class CardUserActivity(
             vTimer.setTextColor(colorGreen)
         } else {
             vUser.visibility = View.VISIBLE
-            vTimer.text = ToolsDate.dayTimeToString_Ms_HH_MM_SS(date - System.currentTimeMillis())
+            vTimer.text = ToolsDate.timeToString(date - System.currentTimeMillis())
             vTimer.setTextColor(colorWhite)
         }
     }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/SSubscribers.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/SSubscribers.kt
@@ -1,0 +1,36 @@
+package com.sayzen.campfiresdk.screens.fandoms
+
+import com.dzen.campfire.api.API_TRANSLATE
+import com.dzen.campfire.api.ApiResources
+import com.dzen.campfire.api.requests.fandoms.RFandomsSubscribersGetAll
+import com.dzen.campfire.api.models.account.Account
+import com.sayzen.campfiresdk.controllers.api
+import com.sayzen.campfiresdk.controllers.t
+import com.sayzen.campfiresdk.models.cards.CardAccount
+import com.sayzen.campfiresdk.support.load
+import com.sup.dev.android.libs.image_loader.ImageLoader
+import com.sup.dev.android.views.screens.SLoadingRecycler
+
+class SSubscribers(
+    private val fandomId: Long,
+    private val languageId: Long,
+) : SLoadingRecycler<CardAccount, Account>() {
+    init {
+        disableShadows()
+        disableNavigation()
+        setTextEmpty(t(API_TRANSLATE.fandom_subscribers_empty))
+        setBackgroundImage(ImageLoader.load(ApiResources.IMAGE_BACKGROUND_24))
+        setTitle(t(API_TRANSLATE.app_subscribers))
+
+        adapter.setBottomLoader { onLoad, cards ->
+            RFandomsSubscribersGetAll(cards.size.toLong(), fandomId, languageId)
+                .onComplete { r -> onLoad.invoke(r.accounts) }
+                .onNetworkError { onLoad.invoke(null) }
+                .send(api)
+        }
+    }
+
+    override fun classOfCard() = CardAccount::class
+
+    override fun map(item: Account) = CardAccount(item)
+}

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/view/CardButtons.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/view/CardButtons.kt
@@ -6,6 +6,7 @@ import com.sayzen.campfiresdk.R
 import com.sayzen.campfiresdk.controllers.t
 import com.sayzen.campfiresdk.models.events.fandom.EventFandomRemoveModerator
 import com.sayzen.campfiresdk.screens.activities.user_activities.SRelayRacesList
+import com.sayzen.campfiresdk.screens.fandoms.SSubscribers
 import com.sayzen.campfiresdk.screens.fandoms.STags
 import com.sayzen.campfiresdk.screens.fandoms.chats.SFandomChatsList
 import com.sayzen.campfiresdk.screens.fandoms.moderation.moderators.SModeration
@@ -32,6 +33,7 @@ class CardButtons(
         val vChatsButton: SettingsMini = view.findViewById(R.id.vChatsButton)
         val vTagsButton: SettingsMini = view.findViewById(R.id.vTagsButton)
         val vModerationButton: SettingsMini = view.findViewById(R.id.vModerationButton)
+        val vUsersButton: SettingsMini = view.findViewById(R.id.vUsersButton)
         val vSubscribersButton: SettingsMini = view.findViewById(R.id.vSubscribersButton)
         val vWikiButton: SettingsMini = view.findViewById(R.id.vWikiButton)
         val vRubricButton: SettingsMini = view.findViewById(R.id.vRubricButton)
@@ -40,7 +42,8 @@ class CardButtons(
         vChatsButton.setTitle(t(API_TRANSLATE.app_chats))
         vTagsButton.setTitle(t(API_TRANSLATE.app_tags))
         vModerationButton.setTitle(t(API_TRANSLATE.app_moderation))
-        vSubscribersButton.setTitle(t(API_TRANSLATE.app_users))
+        vUsersButton.setTitle(t(API_TRANSLATE.app_users))
+        vSubscribersButton.setTitle(t(API_TRANSLATE.app_subscribers))
         vRubricButton.setTitle(t(API_TRANSLATE.app_rubrics))
         vWikiButton.setTitle(t(API_TRANSLATE.app_wiki))
         vRelayRaces.setTitle(t(API_TRANSLATE.app_relay_races))
@@ -49,7 +52,8 @@ class CardButtons(
         vChatsButton.setOnClickListener { Navigator.to(SFandomChatsList(xFandom.getId(), xFandom.getLanguageId())) }
         vTagsButton.setOnClickListener { STags.instance(xFandom.getId(), xFandom.getLanguageId(), Navigator.TO) }
         vModerationButton.setOnClickListener { Navigator.to(SModeration(xFandom.getId(), xFandom.getLanguageId())) }
-        vSubscribersButton.setOnClickListener { Navigator.to(SRating(xFandom.getId(), xFandom.getLanguageId())) }
+        vUsersButton.setOnClickListener { Navigator.to(SRating(xFandom.getId(), xFandom.getLanguageId())) }
+        vSubscribersButton.setOnClickListener { Navigator.to(SSubscribers(xFandom.getId(), xFandom.getLanguageId())) }
         vWikiButton.setOnClickListener { Navigator.to(SWikiList(xFandom.getId(), xFandom.getLanguageId(), 0, "")) }
         vRubricButton.setOnClickListener { Navigator.to(SRubricsList(xFandom.getId(), xFandom.getLanguageId(), 0, true)) }
         vRelayRaces.setOnClickListener { Navigator.to(SRelayRacesList(xFandom.getId(), xFandom.getLanguageId())) }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/view/CardFandomInfo.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/view/CardFandomInfo.kt
@@ -216,7 +216,6 @@ class CardFandomInfo(
             .setMin_2(API.MODERATION_COMMENT_MIN_L)
             .setMax_2(API.MODERATION_COMMENT_MAX_L)
             .setHint_2(t(API_TRANSLATE.comments_hint))
-            .addChecker_2(t(API_TRANSLATE.error_use_english)) { ToolsText.isOnly(it, API.ENGLISH) }
             .setOnEnter(t(API_TRANSLATE.app_change)) { w, cof, comment ->
                 val v = (cof.toDouble() * 100).toLong()
 

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/view/SplashParams.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/fandoms/view/SplashParams.kt
@@ -59,7 +59,6 @@ internal class SplashParams(
 
     private fun updateFinishEnabled() {
 
-        val commentCheck = ToolsText.isOnly(vComment.getText(), API.ENGLISH)
         val newArray = getSelected()
         var changes = selected.size != newArray.size
         if(!changes){
@@ -74,8 +73,7 @@ internal class SplashParams(
                 }
             }
         }
-        vComment.setError(if (commentCheck) null else t(API_TRANSLATE.error_use_english))
-        vEnter.isEnabled = commentCheck && changes && getSelected().isNotEmpty() && vComment.getText().length >= API.MODERATION_COMMENT_MIN_L && vComment.getText().length <= API.MODERATION_COMMENT_MAX_L
+        vEnter.isEnabled = changes && getSelected().isNotEmpty() && vComment.getText().length >= API.MODERATION_COMMENT_MIN_L && vComment.getText().length <= API.MODERATION_COMMENT_MAX_L
     }
 
     private fun getSelected(): Array<Long> {

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/post/create/SplashTagsAdditional.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/post/create/SplashTagsAdditional.kt
@@ -105,7 +105,7 @@ class SplashTagsAdditional(
                     .setOnEnter(t(API_TRANSLATE.app_choose)) { _, date ->
                         SplashChooseTime()
                                 .setOnEnter(t(API_TRANSLATE.app_choose)) { _, h, m ->
-                                    setPendingDate(ToolsDate.getStartOfDay_GlobalTimeZone(date) + (h * 60L * 60 * 1000) + (m * 60L * 1000))
+                                    setPendingDate(ToolsDate.getStartOfDay(date) + (h * 60L * 60 * 1000) + (m * 60L * 1000))
                                 }
                                 .asSheetShow()
                     }

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/punishments/CardPunishment.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/screens/punishments/CardPunishment.kt
@@ -44,7 +44,7 @@ class CardPunishment(
                     API_TRANSLATE.he_blocked,
                     API_TRANSLATE.she_blocked
                 ),
-                ToolsDate.dateToStringFull(punishment.banDate)
+                ToolsDate.dateToString(punishment.banDate, false)
             )
             else text = tCap(
                 API_TRANSLATE.profile_punishment_card_warn_admin,
@@ -63,7 +63,7 @@ class CardPunishment(
                     API_TRANSLATE.she_blocked
                 ),
                 "" + punishment.fandomName,
-                ToolsDate.dateToStringFull(punishment.banDate)
+                ToolsDate.dateToString(punishment.banDate, false)
             )
             else text = tCap(
                 API_TRANSLATE.profile_punishment_card_warn,

--- a/CampfireSDK/src/main/java/com/sayzen/campfiresdk/support/ApiRequestsSupporter.kt
+++ b/CampfireSDK/src/main/java/com/sayzen/campfiresdk/support/ApiRequestsSupporter.kt
@@ -61,7 +61,7 @@ object ApiRequestsSupporter {
     fun <K : Request.Response> execute(request: Request<K>, sendNow:Boolean, onComplete: (K) -> Unit): Request<K> {
         request.onComplete { r -> onComplete.invoke(r) }
                 .onNetworkError { ToolsToast.show(SupAndroid.TEXT_ERROR_NETWORK) }
-                .onApiError(ApiClient.ERROR_ACCOUNT_IS_BANED) { ex -> ToolsToast.show(String.format(SupAndroid.TEXT_ERROR_ACCOUNT_BANED!!, ToolsDate.dateToStringFull(java.lang.Long.parseLong(ex.params[0])))) }
+                .onApiError(ApiClient.ERROR_ACCOUNT_IS_BANED) { ex -> ToolsToast.show(String.format(SupAndroid.TEXT_ERROR_ACCOUNT_BANED!!, ToolsDate.dateToString(java.lang.Long.parseLong(ex.params[0]), false))) }
                 .onApiError(ApiClient.ERROR_GONE) { ToolsToast.show(SupAndroid.TEXT_ERROR_GONE) }
 
         if(sendNow)request.sendNow(api!!)
@@ -75,7 +75,7 @@ object ApiRequestsSupporter {
         onApiError(ApiClient.ERROR_ACCOUNT_IS_BANED) { ex ->
             ToolsToast.show(
                 SupAndroid.TEXT_ERROR_ACCOUNT_BANED!!
-                    .format(ToolsDate.dateToStringFull(ex.params[0].toLong()))
+                    .format(ToolsDate.dateToString(ex.params[0].toLong(), false))
             )
         }
         onApiError(ApiClient.ERROR_GONE) {

--- a/CampfireSDK/src/main/res/layout/screen_fandom_card_buttons.xml
+++ b/CampfireSDK/src/main/res/layout/screen_fandom_card_buttons.xml
@@ -42,6 +42,14 @@
             app:Settings_icon="@drawable/ic_security_white_24dp"/>
 
         <com.sup.dev.android.views.settings.SettingsMini
+            android:id="@+id/vUsersButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:Settings_lineVisible="false"
+            app:Settings_icon_filter="?colorOnPrimaryIcons"
+            app:Settings_icon="@drawable/ic_group_white_24dp"/>
+
+        <com.sup.dev.android.views.settings.SettingsMini
             android:id="@+id/vSubscribersButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/CampfireSDK/src/main/resources/lang/ru.json
+++ b/CampfireSDK/src/main/resources/lang/ru.json
@@ -1013,6 +1013,7 @@
     "history_edit_public": "Публикация отредактирована",
     "history_multilingual": "Публикация сделана мультиязычной",
     "history_not_multilingual": "Публикация сделана не мультиязычной",
+    "history_pending": "Публикация отложена до %s",
     "history_pin_profile": "Публикация закреплена в профиле",
     "history_publish": "Публикация опубликована",
     "history_set_nsfw_false": "Публикация отмечена как NSFW",

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/app/App.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/app/App.kt
@@ -21,6 +21,7 @@ object App {
     val secrets = Json(ToolsFiles.readString("secrets/Secrets.json"))
     val secretsBotsTokens = secrets.getStrings("bots_tokens")!!.map { it?:"" }.toTypedArray()
     val secretsConfig = secrets.getJson("config")!!
+    val secretsApi = secrets.getJson("api")!!
     val secretsKeys = secrets.getJson("keys")!!
     val secretsS3 = secrets.getJson("s3")!!
     val test = secretsConfig.getString("build_type")!="release"
@@ -44,6 +45,11 @@ object App {
             System.err.println(ToolsDate.getTimeZoneName() + " ( " + ToolsDate.getTimeZoneHours() + " )")
             System.err.println("Charset: " + Charset.defaultCharset())
             System.err.println("API Version: " + API.VERSION)
+
+            API.SERV_ROOT = secretsApi["server_root"]!!
+            API.MELIOR_ROOT = secretsApi["server_melior"]!!
+            API.S3_ROOT = secretsApi["server_s3"]!!
+            API.DOMEN = "https://${secretsApi.getString("host")!!}/r/"
 
             GoogleNotification.init(googleNotificationKey, arrayOf())
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/app/App.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/app/App.kt
@@ -6,7 +6,6 @@ import com.dzen.campfire.api.tools.server.RequestFactory
 import com.dzen.campfire.server.controllers.*
 import com.sup.dev.java.libs.debug.err
 import com.sup.dev.java.libs.json.Json
-import com.sup.dev.java.tools.ToolsDate
 import com.sup.dev.java.tools.ToolsFiles
 import com.sup.dev.java.tools.ToolsThreads
 import com.sup.dev.java_pc.google.GoogleNotification
@@ -42,7 +41,6 @@ object App {
 
         try {
             System.err.println("Sayzen Studio")
-            System.err.println(ToolsDate.getTimeZoneName() + " ( " + ToolsDate.getTimeZoneHours() + " )")
             System.err.println("Charset: " + Charset.defaultCharset())
             System.err.println("API Version: " + API.VERSION)
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/controllers/ControllerModeration.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/controllers/ControllerModeration.kt
@@ -5,6 +5,8 @@ import com.dzen.campfire.api.tools.ApiException
 
 object ControllerModeration {
     fun parseComment(comment: String, userId: Long = 0L): String {
+        val comment = comment.trim()
+
         if (ControllerCensor.containsSwearing(comment)) {
             val account = ControllerAccounts.getAccount(userId)
             if (account != null) {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/controllers/ControllerPending.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/controllers/ControllerPending.kt
@@ -1,10 +1,12 @@
 package com.dzen.campfire.server.controllers
 
 import com.dzen.campfire.api.API
+import com.dzen.campfire.api.models.publications.history.HistoryPublish
 import com.dzen.campfire.api.models.publications.post.PageText
 import com.dzen.campfire.api.models.publications.post.PublicationPost
 import com.dzen.campfire.api.tools.ApiAccount
 import com.dzen.campfire.api.tools.ApiException
+import com.dzen.campfire.server.tables.TAccounts
 import com.dzen.campfire.server.tables.TPublications
 import com.sup.dev.java.tools.ToolsThreads
 import com.sup.dev.java_pc.sql.Database
@@ -29,7 +31,17 @@ object ControllerPending {
     }
 
     private fun posts(){
-        val v = Database.select("ControllerPending.posts select", SqlQuerySelect(TPublications.NAME, TPublications.id, TPublications.fandom_id, TPublications.language_id, TPublications.tag_3, TPublications.creator_id)
+        val v = Database.select("ControllerPending.posts select",
+            SqlQuerySelect(
+                TPublications.NAME,
+                TPublications.id,
+                TPublications.fandom_id,
+                TPublications.language_id,
+                TPublications.tag_3,
+                TPublications.creator_id,
+                TAccounts.NAME(TPublications.creator_id),
+                TAccounts.IMAGE_ID(TPublications.creator_id)
+            )
                 .where(TPublications.status, "=", API.STATUS_PENDING)
                 .where(TPublications.publication_type, "=", API.PUBLICATION_TYPE_POST)
                 .where(TPublications.tag_4, "<", System.currentTimeMillis())
@@ -37,10 +49,12 @@ object ControllerPending {
 
         while (v.hasNext()){
             val id: Long = v.next()
-            val fandomId:Long = v.next()
-            val languageId:Long = v.next()
-            val willNotify:Long = v.next()
-            val creatorId:Long = v.next()
+            val fandomId: Long = v.next()
+            val languageId: Long = v.next()
+            val willNotify: Long = v.next()
+            val creatorId: Long = v.next()
+            val creatorName: String = v.next()
+            val creatorImageId: Long = v.next()
 
             try {
                 val pub = ControllerPublications.getPublication(id, 0)!! as PublicationPost
@@ -63,6 +77,11 @@ object ControllerPending {
             try {
                 ControllerAccounts.checkAccountBanned(creatorId, fandomId, languageId)
                 ControllerPost.publish(id, willNotify, creatorId)
+
+                ControllerPublicationsHistory.put(
+                    id,
+                    HistoryPublish(creatorId, creatorImageId, creatorName)
+                )
             } catch (e: ApiException) {
                 Database.update("ControllerPending.posts update_2", SqlQueryUpdate(TPublications.NAME)
                         .where(TPublications.id, "=", id)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/controllers/ControllerPublications.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/controllers/ControllerPublications.kt
@@ -97,7 +97,7 @@ object ControllerPublications {
             return
         }
         if(OptimizerEffects.get(fromAccount.id, API.EFFECT_INDEX_MENTION_LOCK) != null) return
-        val textV = text.replace(API.LINK_PROFILE_NAME, API.LINK_SHORT_PROFILE)
+        val textV = text.replace(API.LINK_PROFILE_NAME.asWeb(), API.LINK_SHORT_PROFILE)
         val names = ArrayList<String>()
         val ids = ArrayList<Long>()
         var i = 0

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAchievementsRecount.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAchievementsRecount.kt
@@ -9,6 +9,7 @@ class EAccountsAchievementsRecount : RAccountsAchievementsRecount(0, "") {
 
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_DEBUG_RECOUNT_LEVEL_AND_KARMA)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminBan.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminBan.kt
@@ -13,7 +13,7 @@ class EAccountsAdminBan() : RAccountsAdminBan(0, 0, "") {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_BAN)
         if (banTime > 1000L * 60 * 60 * 24 * 365) throw ApiException(API.ERROR_ACCESS)
         if (!ControllerFandom.checkCanModerate(apiAccount, accountId)) throw ApiException(E_LOW_KARMA_FORCE)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminChangeName.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminChangeName.kt
@@ -12,7 +12,7 @@ class EAccountsAdminChangeName : RAccountsAdminChangeName(0L, "", "") {
     override fun check() {
         if (!ToolsText.isValidUsername(name)) throw ApiException(E_LOGIN_CHARS)
 
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         if (ControllerAccounts.getByName(name) != 0L) throw ApiException(E_LOGIN_NOT_ENABLED)
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_USER_CHANGE_NAME)
         ControllerFandom.checkCanModerate(apiAccount, accountId)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminEffectAdd.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminEffectAdd.kt
@@ -9,7 +9,7 @@ import com.dzen.campfire.api.tools.ApiException
 class EAccountsAdminEffectAdd : RAccountsAdminEffectAdd(0L, 0L, 0L, "") {
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_FANDOM_EFFECTS)
         if(accountId == apiAccount.id) throw ApiException(API.ERROR_ACCESS)
     }

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminEffectRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminEffectRemove.kt
@@ -20,7 +20,7 @@ class EAccountsAdminEffectRemove : RAccountsAdminEffectRemove(0L, "") {
     var m = MAccountEffect()
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_FANDOM_EFFECTS)
 
         val m = ControllerEffects.get(effectId)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminPunishmentsRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminPunishmentsRemove.kt
@@ -13,7 +13,7 @@ class EAccountsAdminPunishmentsRemove : RAccountsAdminPunishmentsRemove(0, "") {
     override fun check() {
         punishment = ControllerAccounts.getPunishment(punishmentId)
         if (punishment == null) throw ApiException(API.ERROR_GONE)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         if (punishment!!.ownerId == apiAccount.id && apiAccount.id != 1L) throw ApiException(API.ERROR_ACCESS)
         if (punishment!!.fromAccountId != apiAccount.id)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminRemoveDescription.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminRemoveDescription.kt
@@ -14,7 +14,7 @@ class EAccountsAdminRemoveDescription : RAccountsAdminRemoveDescription(0,"") {
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_USER_REMOVE_DESCRIPTION)
         ControllerFandom.checkCanModerate(apiAccount, accountId)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminRemoveLink.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminRemoveLink.kt
@@ -16,7 +16,7 @@ class EAccountsAdminRemoveLink : RAccountsAdminRemoveLink(0, 0, "") {
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_USER_REMOVE_LINK)
         ControllerFandom.checkCanModerate(apiAccount, accountId)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminStatusRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsAdminStatusRemove.kt
@@ -16,7 +16,7 @@ class EAccountsAdminStatusRemove : RAccountsAdminStatusRemove(0L, "") {
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_USER_REMOVE_STATUS)
         ControllerFandom.checkCanModerate(apiAccount, accountId)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsClearReports.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsClearReports.kt
@@ -8,6 +8,7 @@ import com.dzen.campfire.server.controllers.ControllerFandom
 import com.dzen.campfire.api.tools.ApiException
 import com.dzen.campfire.server.controllers.ControllerAccounts
 import com.dzen.campfire.server.controllers.ControllerAdminVote
+import com.dzen.campfire.server.controllers.ControllerModeration
 import com.dzen.campfire.server.tables.TAccounts
 import com.sup.dev.java_pc.sql.Database
 import com.sup.dev.java_pc.sql.SqlQueryUpdate
@@ -17,6 +18,7 @@ class EAccountsClearReports : RAccountsClearReports(0, "") {
     @Throws(ApiException::class)
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_BAN)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsKarmaRecount.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsKarmaRecount.kt
@@ -10,6 +10,7 @@ class EAccountsKarmaRecount : RAccountsKarmaRecount(0, "") {
 
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_DEBUG_RECOUNT_LEVEL_AND_KARMA)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsRemoveAvatar.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsRemoveAvatar.kt
@@ -15,6 +15,7 @@ class EAccountsRemoveAvatar : RAccountsRemoveAvatar(0, "") {
     @Throws(ApiException::class)
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_USER_REMOVE_IMAGE)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsRemoveName.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsRemoveName.kt
@@ -18,6 +18,7 @@ class EAccountsRemoveName : RAccountsRemoveName(0, "") {
     @Throws(ApiException::class)
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_USER_REMOVE_NAME)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsRemoveTitleImage.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/accounts/EAccountsRemoveTitleImage.kt
@@ -17,6 +17,7 @@ class EAccountsRemoveTitleImage : RAccountsRemoveTitleImage(0, "") {
     @Throws(ApiException::class)
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_USER_REMOVE_IMAGE)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/activities/EActivitiesRelayRaceChange.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/activities/EActivitiesRelayRaceChange.kt
@@ -18,7 +18,7 @@ class EActivitiesRelayRaceChange : RActivitiesRelayRaceChange(0, "", "", "") {
     private var activity = UserActivity()
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         val activity = ControllerActivities.getActivity(activityId, apiAccount.id)
         if(activity == null) throw ApiException(API.ERROR_GONE)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/activities/EActivitiesRelayRaceCreate.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/activities/EActivitiesRelayRaceCreate.kt
@@ -15,7 +15,7 @@ class EActivitiesRelayRaceCreate() : RActivitiesRelayRaceCreate(0,0,0,"","", "")
     override fun check() {
         name = ControllerCensor.cens(name)
         description = ControllerCensor.cens(description)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         ControllerFandom.checkCan(apiAccount, fandomId, languageId, API.LVL_MODERATOR_RELAY_RACE)
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/activities/EActivitiesRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/activities/EActivitiesRemove.kt
@@ -15,7 +15,7 @@ class EActivitiesRemove : RActivitiesRemove(0, "") {
     private var activity = UserActivity()
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         val activity = ControllerActivities.getActivity(activityId, apiAccount.id)
         if(activity == null) throw ApiException(API.ERROR_GONE)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/admins/EAdminVoteCancel.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/admins/EAdminVoteCancel.kt
@@ -14,6 +14,7 @@ class EAdminVoteCancel : RAdminVoteCancel(0, "") {
 
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_BAN)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/chat/EChatMessageCreate.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/chat/EChatMessageCreate.kt
@@ -13,6 +13,8 @@ import com.dzen.campfire.server.tables.TFandoms
 import com.sup.dev.java.libs.json.Json
 import com.sup.dev.java.tools.ToolsBytes
 import com.sup.dev.java.tools.ToolsCryptography
+import com.sup.dev.java_pc.sql.Database
+import com.sup.dev.java_pc.sql.SqlQuerySelect
 import com.sup.dev.java_pc.tools.ToolsImage
 import java.nio.ByteBuffer
 import kotlin.math.abs
@@ -46,10 +48,11 @@ class EChatMessageCreate(
                 0
         )
         message.chatType = tag.chatType
-        message.fandom.id = tag.targetId
-        message.fandom.languageId = tag.targetSubId
 
         if (message.chatType == API.CHAT_TYPE_FANDOM_ROOT) {
+            message.fandom.id = tag.targetId
+            message.fandom.languageId = tag.targetSubId
+
             if (!API.isLanguageExsit(tag.targetSubId)) throw ApiException(API.ERROR_GONE)
             if (ControllerFandom.get(tag.targetId, TFandoms.status).next<Long>() != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
             ControllerAccounts.checkAccountBanned(apiAccount.id, message.fandom.id, message.fandom.languageId)
@@ -60,7 +63,8 @@ class EChatMessageCreate(
 
         } else if (message.chatType == API.CHAT_TYPE_PRIVATE) {
             ControllerAccounts.checkAccountBanned(apiAccount.id)
-            val v = ControllerAccounts.get(message.fandom.id, TAccounts.name, TAccounts.img_id)
+            val v = ControllerAccounts.get(tag.targetId, TAccounts.name, TAccounts.img_id)
+            message.fandom.id = tag.targetId
             message.fandom.name = v.next()
             message.fandom.imageId = v.next()
         } else if (message.chatType == API.CHAT_TYPE_CONFERENCE) {
@@ -73,17 +77,29 @@ class EChatMessageCreate(
             }
 
             if (!ControllerChats.hasAccessToConf_Write(apiAccount.id, tag.targetId)) throw ApiException(API.ERROR_ACCESS)
-            val v = ControllerChats.getChat(message.fandom.id, TChats.name, TChats.image_id)
+            val v = ControllerChats.getChat(tag.targetId, TChats.name, TChats.image_id)
+            message.fandom.id = tag.targetId
             message.fandom.name = v.next()
             message.fandom.imageId = v.next()
         } else if (message.chatType == API.CHAT_TYPE_FANDOM_SUB) {
+            val chatSelect = Database.select("EChatMessageCreate.subChatCheck select",
+                SqlQuerySelect(
+                    TChats.NAME,
+                    TChats.fandom_id,
+                    TChats.language_id
+                )
+                .where(TChats.id, "=", tag.targetId)
+            )
+            if (chatSelect.isEmpty) throw ApiException(API.ERROR_GONE)
+            message.fandom.id = chatSelect.next()
+            message.fandom.languageId = chatSelect.next()
+
             ControllerAccounts.checkAccountBanned(apiAccount.id, message.fandom.id, message.fandom.languageId)
             val v = ControllerFandom[message.fandom.id, TFandoms.name, TFandoms.image_id, TFandoms.fandom_category]
             message.fandom.name = v.next()
             message.fandom.imageId = v.next()
             message.category = v.next()
-
-        }else {
+        } else {
             throw ApiException(E_BAD_CHAT_TYPE)
         }
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAccept.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAccept.kt
@@ -32,6 +32,9 @@ class EFandomsAccept : RFandomsAccept(0, false, "") {
             if (fandom == null) throw ApiException(API.ERROR_GONE)
             if (fandom.status != API.STATUS_DRAFT) throw ApiException(E_BAD_STATUS)
             if (fandom.creatorId == apiAccount.id) throw ApiException(E_SELF)
+            if (!accepted) {
+                comment = ControllerModeration.parseComment(comment, apiAccount.id)
+            }
             this.fandom = fandom
         }
     }

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeCategory.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeCategory.kt
@@ -20,7 +20,7 @@ class EFandomsAdminChangeCategory : RFandomsAdminChangeCategory(0, 0, "") {
         fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeImage.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeImage.kt
@@ -23,7 +23,7 @@ class EFandomsAdminChangeImage : RFandomsAdminChangeImage(0, ByteArray(0), "") {
         fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if(fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeName.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeName.kt
@@ -23,7 +23,7 @@ class EFandomsAdminChangeName : RFandomsAdminChangeName(0, "", "") {
         fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeParams.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminChangeParams.kt
@@ -31,7 +31,7 @@ class EFandomsAdminChangeParams : RFandomsAdminChangeParams(0, 0, 0, emptyArray(
         ) throw ApiException(E_BAD_TYPE)
 
         if (paramsPosition < 1 || paramsPosition > 4) throw ApiException(E_BAD_TYPE)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminClose.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminClose.kt
@@ -24,7 +24,7 @@ class EFandomsAdminClose : RFandomsAdminClose(0, false, "") {
         fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminMakeModerator.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminMakeModerator.kt
@@ -28,7 +28,7 @@ class EFandomsAdminMakeModerator : RFandomsAdminMakeModerator(0, "") {
         if (ControllerFandom.getModerators(publication.fandom.id, publication.fandom.languageId).size > 1) throw ApiException(E_FANDOM_HAVE_MODERATORS)
         if (publication.creator.lvl < API.LVL_MODERATOR_BLOCK.lvl) throw ApiException(E_LOW_LVL)
         if (publication.fandom.languageId == -1L) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminRemove.kt
@@ -27,7 +27,7 @@ class EFandomsAdminRemove : RFandomsAdminRemove(0, "") {
         fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminRemoveModerator.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminRemoveModerator.kt
@@ -22,7 +22,7 @@ class EFandomsAdminRemoveModerator : RFandomsAdminRemoveModerator(0, 0, 0, "") {
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_REMOVE_MODERATOR)
         karma30 = ControllerFandom.getKarma30(accountId, fandomId, languageId)
         if (karma30 < API.LVL_MODERATOR_BLOCK.karmaCount) throw ApiException(E_NOT_MODERATOR)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminViceroyAssign.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminViceroyAssign.kt
@@ -23,7 +23,7 @@ class EFandomsAdminViceroyAssign : RFandomsAdminViceroyAssign(0, 0, 0, "") {
         val fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         fandom.languageId = languageId
         this.fandom = fandom

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminViceroyRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsAdminViceroyRemove.kt
@@ -20,7 +20,7 @@ class EFandomsAdminViceroyRemove : RFandomsAdminViceroyRemove(0, 0, "") {
         val fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         fandom.languageId = languageId
         this.fandom = fandom

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationBlock.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationBlock.kt
@@ -57,7 +57,7 @@ class EFandomsModerationBlock : RFandomsModerationBlock(0, 0, false, "", false, 
                 )
         ) throw ApiException(E_LOW_KARMA_FORCE)
         if (blockTime > 1000L * 60 * 60 * 24 * 365) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         val canBlockTag = ControllerVahter.isCanBlock(apiAccount.id)
         if(canBlockTag != -1L){

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChangeImageBackground.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChangeImageBackground.kt
@@ -19,7 +19,7 @@ class EFandomsModerationChangeImageBackground : RFandomsModerationChangeImageBac
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
 
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         if(image != null) {
             if (image!!.size > API.CHAT_IMG_BACKGROUND_WEIGHT) throw ApiException(E_BAD_IMG_WEIGHT, " " + image!!.size + " > " + API.ACCOUNT_IMG_WEIGHT)
             if (!ToolsImage.checkImageMaxScaleUnknownType(image!!, API.CHAT_IMG_BACKGROUND_W, API.CHAT_IMG_BACKGROUND_H, true, true, true)) throw ApiException(E_BAD_IMG_SIDES)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChangeImageTitle.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChangeImageTitle.kt
@@ -17,7 +17,7 @@ class EFandomsModerationChangeImageTitle : RFandomsModerationChangeImageTitle(0,
         fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
 
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChatChange.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChatChange.kt
@@ -25,7 +25,7 @@ class EFandomsModerationChatChange : RFandomsModerationChatChange(0, "", "", "",
     override fun check() {
         name = ControllerCensor.cens(name)
         text = ControllerCensor.cens(text)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         val v = Database.select("EFandomsModerationChatChange select", SqlQuerySelect(TChats.NAME, TChats.fandom_id, TChats.language_id, TChats.name, TChats.image_id)
                 .where(TChats.id, "=", chatId)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChatCreate.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChatCreate.kt
@@ -17,7 +17,7 @@ class EFandomsModerationChatCreate : RFandomsModerationChatCreate(0, 0, "", "", 
 
     @Throws(ApiException::class)
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         name = ControllerCensor.cens(name)
         text = ControllerCensor.cens(text)
         ControllerFandom.checkCan(apiAccount, fandomId, languageId, API.LVL_MODERATOR_CHATS)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChatRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationChatRemove.kt
@@ -21,7 +21,7 @@ class EFandomsModerationChatRemove : RFandomsModerationChatRemove(0, "") {
 
     @Throws(ApiException::class)
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         val v = Database.select("EFandomsModerationChatRemove select", SqlQuerySelect(TChats.NAME, TChats.fandom_id, TChats.language_id, TChats.name)
                 .where(TChats.id, "=", chatId)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationDescriptionChange.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationDescriptionChange.kt
@@ -18,7 +18,7 @@ class EFandomsModerationDescriptionChange : RFandomsModerationDescriptionChange(
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if(fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
         if(description.length > API.FANDOM_DESCRIPTION_MAX_L) throw ApiException(E_BAD_TEXT_LENGTH)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationForgive.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationForgive.kt
@@ -12,7 +12,7 @@ class EFandomsModerationForgive : RFandomsModerationForgive(0, 0, 0, "") {
 
     override fun check() {
         ControllerFandom.checkCan(apiAccount, fandomId, languageId, API.LVL_MODERATOR_BLOCK)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationGalleryAdd.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationGalleryAdd.kt
@@ -20,7 +20,7 @@ class EFandomsModerationGalleryAdd : RFandomsModerationGalleryAdd(0, 0, null, ""
         if(ControllerCollisions.getCollisionsCount(fandomId,languageId, API.COLLISION_FANDOM_GALLERY) >= API.FANDOM_GALLERY_MAX)  throw ApiException(E_TOO_MANY_ITEMS)
         if(image == null || image!!.size > API.FANDOM_GALLERY_MAX_WEIGHT) throw ApiException(E_BAD_IMAGE)
         if(!ToolsImage.checkImageMaxScaleUnknownType(image!!, API.FANDOM_GALLERY_MAX_SIDE, API.FANDOM_GALLERY_MAX_SIDE, true, false, true)) throw ApiException(E_BAD_IMAGE)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationGalleryRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationGalleryRemove.kt
@@ -16,7 +16,7 @@ class EFandomsModerationGalleryRemove : RFandomsModerationGalleryRemove(0, 0, 0,
         fandom = ControllerFandom.getFandom(fandomId)
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationImportant.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationImportant.kt
@@ -26,7 +26,7 @@ class EFandomsModerationImportant : RFandomsModerationImportant(0, false, "") {
             API.LVL_MODERATOR_IMPORTANT
         )
         if (publication.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationLinkAdd.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationLinkAdd.kt
@@ -21,7 +21,7 @@ class EFandomsModerationLinkAdd : RFandomsModerationLinkAdd(0, 0, "", "", 0, "")
         if(url.length > API.FANDOM_LINKS_URL_MAX_L) throw ApiException(E_BAD_SIZE)
         if(title.length > API.FANDOM_LINKS_TITLE_MAX_L) throw ApiException(E_BAD_SIZE)
         if(ControllerCollisions.getCollisionsCount(fandomId,languageId, API.COLLISION_FANDOM_LINK) >= API.FANDOM_LINKS_MAX)  throw ApiException(E_BAD_COUNT)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationLinkChange.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationLinkChange.kt
@@ -23,7 +23,7 @@ class EFandomsModerationLinkChange : RFandomsModerationLinkChange(0, 0, 0, "", "
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
         if (url.length > API.FANDOM_LINKS_URL_MAX_L) throw ApiException(E_BAD_SIZE)
         if (title.length > API.FANDOM_LINKS_TITLE_MAX_L) throw ApiException(E_BAD_SIZE)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationLinkRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationLinkRemove.kt
@@ -27,7 +27,7 @@ class EFandomsModerationLinkRemove : RFandomsModerationLinkRemove(0, "") {
         if (fandom == null) throw ApiException(API.ERROR_GONE)
         if (fandom!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
         if (collisionType != API.COLLISION_FANDOM_LINK) throw ApiException(E_BAD_TYPE)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationNames.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationNames.kt
@@ -16,7 +16,7 @@ class EFandomsModerationNames : RFandomsModerationNames(0, 0, emptyArray(), "") 
             names[i] = ControllerCensor.cens(names[i])
             if (names[i].length > API.FANDOM_NAMES_MAX_L) throw ApiException(E_BAD_SIZE)
         }
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationToDrafts.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/fandoms/EFandomsModerationToDrafts.kt
@@ -37,7 +37,7 @@ class EFandomsModerationToDrafts : RFandomsModerationToDrafts(0, "") {
         } else if (publication is QuestDetails) {
             ControllerFandom.checkCan(apiAccount, API.LVL_QUEST_MODERATOR)
         }
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostAdminRemoveMedia.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostAdminRemoveMedia.kt
@@ -21,7 +21,7 @@ class EPostAdminRemoveMedia : RPostAdminRemoveMedia(0, "") {
         if(publication.fandom.languageId == -1L) throw ApiException(API.ERROR_ACCESS)
         if(publication.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
 
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_REMOVE_MEDIA)
     }
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostChangeFandom.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostChangeFandom.kt
@@ -28,7 +28,7 @@ class EPostChangeFandom : RPostChangeFandom(0, 0, 0, "") {
         if(publication.status != API.STATUS_DRAFT && publication.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
 
         if(publication.creator.id != apiAccount.id){
-            ControllerModeration.parseComment(comment, apiAccount.id)
+            comment = ControllerModeration.parseComment(comment, apiAccount.id)
             ControllerFandom.checkCan(apiAccount, API.LVL_ADMIN_POST_CHANGE_FANDOM)
         }else{
             ControllerAccounts.checkAccountBanned(apiAccount.id)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostCloseModerator.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostCloseModerator.kt
@@ -17,7 +17,7 @@ class EPostCloseModerator : RPostCloseModerator(0, "") {
     var publication = PublicationPost()
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         val publication = ControllerPublications.getPublication(publicationId, apiAccount.id)
         if(publication == null) throw ApiException(API.ERROR_GONE)
         if(publication.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_GONE)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostCloseNoModerator.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostCloseNoModerator.kt
@@ -17,7 +17,7 @@ class EPostCloseNoModerator : RPostCloseNoModerator(0, "") {
     var publication = PublicationPost()
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         val publication = ControllerPublications.getPublication(publicationId, apiAccount.id)
         if(publication == null) throw ApiException(API.ERROR_GONE)
         if(publication.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_GONE)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostGetAllByTag.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostGetAllByTag.kt
@@ -23,6 +23,7 @@ class EPostGetAllByTag : RPostGetAllByTag(0, 0) {
     override fun execute(): Response {
 
         val v = Database.select("EPostGetAllByTag select_1",SqlQuerySelect(TCollisions.NAME, TCollisions.owner_id)
+                .where(TCollisions.collision_type, "=", API.COLLISION_TAG)
                 .where(TCollisions.collision_id, "=", tagId)
                 .where(SqlWhere.WhereString("${API.STATUS_PUBLIC}=(SELECT ${TPublications.status} FROM ${TPublications.NAME} WHERE ${TPublications.id}=${TCollisions.owner_id})"))
                 .offset_count(offset, COUNT)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostMakeMultilingualModeratorNot.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostMakeMultilingualModeratorNot.kt
@@ -25,7 +25,7 @@ class EPostMakeMultilingualModeratorNot : RPostMakeMultilingualModeratorNot(0, "
 
         ControllerFandom.checkCan(apiAccount, publication.fandom.id, publication.fandom.languageId, API.LVL_MODERATOR_TO_DRAFTS)
         if (!ControllerFandom.checkCanModerate(apiAccount, publication.creator.id, publication.fandom.id, publication.fandom.languageId)) throw ApiException(E_LOW_KARMA_FORCE)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
     }
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPendingPublish.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPendingPublish.kt
@@ -1,11 +1,13 @@
 package com.dzen.campfire.server.executors.post
 
 import com.dzen.campfire.api.API
+import com.dzen.campfire.api.models.publications.history.HistoryPublish
 import com.dzen.campfire.api.models.publications.post.PublicationPost
 import com.dzen.campfire.api.requests.post.RPostPendingPublish
 import com.dzen.campfire.server.controllers.ControllerAccounts
 import com.dzen.campfire.server.controllers.ControllerPost
 import com.dzen.campfire.server.controllers.ControllerPublications
+import com.dzen.campfire.server.controllers.ControllerPublicationsHistory
 import com.dzen.campfire.api.tools.ApiException
 
 class EPostPendingPublish : RPostPendingPublish(0) {
@@ -28,6 +30,12 @@ class EPostPendingPublish : RPostPendingPublish(0) {
 
     override fun execute(): Response {
         ControllerPost.publish(publicationId, publication.tag_3, publication.creator.id)
+
+        ControllerPublicationsHistory.put(
+            publicationId,
+            HistoryPublish(apiAccount.id, apiAccount.imageId, apiAccount.name)
+        )
+
         return Response()
     }
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPinFandom.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPinFandom.kt
@@ -12,7 +12,7 @@ import com.dzen.campfire.api.tools.ApiException
 class EPostPinFandom : RPostPinFandom(0, 0, 0, "") {
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         if (postId > 0L) {
             val publication = ControllerPublications.getPublication(postId, apiAccount.id)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPublication.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPublication.kt
@@ -5,6 +5,7 @@ import com.dzen.campfire.api.models.fandoms.Fandom
 import com.dzen.campfire.api.models.notifications.post.NotificationModerationPostTags
 import com.dzen.campfire.api.models.publications.history.HistoryAdminChangeTags
 import com.dzen.campfire.api.models.publications.history.HistoryChangeTags
+import com.dzen.campfire.api.models.publications.history.HistoryPending
 import com.dzen.campfire.api.models.publications.history.HistoryPublish
 import com.dzen.campfire.api.models.publications.moderations.posts.ModerationPostTags
 import com.dzen.campfire.api.models.publications.post.PageText
@@ -132,7 +133,17 @@ class EPostPublication : RPostPublication(0, emptyArray(), "", false, 0, false, 
             ControllerAchievements.addAchievementWithCheck(apiAccount.id, API.ACHI_FIRST_POST)
 
             ControllerPublications.watchComments(apiAccount.id, publicationId, true)
-            ControllerPublicationsHistory.put(publicationId, HistoryPublish(apiAccount.id, apiAccount.imageId, apiAccount.name))
+            if (pendingTime == 0L) {
+                ControllerPublicationsHistory.put(
+                    publicationId,
+                    HistoryPublish(apiAccount.id, apiAccount.imageId, apiAccount.name)
+                )
+            } else {
+                ControllerPublicationsHistory.put(
+                    publicationId,
+                    HistoryPending(apiAccount.id, apiAccount.imageId, apiAccount.name, pendingTime)
+                )
+            }
 
             ControllerAchievements.addAchievementWithCheck(
                 ControllerViceroy.getViceroyId(publication!!.fandom.id, publication!!.fandom.languageId),

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPublication.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostPublication.kt
@@ -39,7 +39,7 @@ class EPostPublication : RPostPublication(0, emptyArray(), "", false, 0, false, 
         if (publication!!.creator.id != apiAccount.id && publication!!.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
         if (publication!!.creator.id != apiAccount.id && pendingTime > 0) throw ApiException(API.ERROR_ACCESS)
         if (publication!!.creator.id != apiAccount.id) {
-            ControllerModeration.parseComment(comment, apiAccount.id)
+            comment = ControllerModeration.parseComment(comment, apiAccount.id)
             ControllerFandom.checkCan(apiAccount, publication!!.fandom.id, publication!!.fandom.languageId, API.LVL_MODERATOR_POST_TAGS)
         }
         if (publication!!.publicationType != API.PUBLICATION_TYPE_POST) throw ApiException(E_BAD_TYPE)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostSetNsfwModerator.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/post/EPostSetNsfwModerator.kt
@@ -17,7 +17,7 @@ class EPostSetNsfwModerator : RPostSetNsfwModerator(0, false, "") {
     var publication = PublicationPost()
 
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         val publication = ControllerPublications.getPublication(publicationId, apiAccount.id)
             ?: throw ApiException(API.ERROR_GONE)
         if (publication.status != API.STATUS_PUBLIC) {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/project/EProjectMakeHelloPost.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/project/EProjectMakeHelloPost.kt
@@ -13,20 +13,10 @@ import com.sup.dev.java_pc.sql.Database
 
 class EProjectMakeHelloPost : RProjectMakeHelloPost("", false, "", 0) {
 
-    companion object {
-        val hash = HashMap<Long, Long>()
-        var TIME = 1000L * 60 * 60
-    }
-
     override fun check() {
     }
 
     override fun execute(): Response {
-
-        if (!hash.containsKey(languageId)) hash.put(languageId, 0)
-
-        if (hash[languageId]!! > System.currentTimeMillis() - TIME) return Response(0)
-        hash[languageId] = System.currentTimeMillis()
         ControllerAccounts.checkAccountBanned(apiAccount.id)
 
         val fandomId = API.FANDOM_CAMPFIRE_HELLO_ID

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/publications/EPublicationsAdminRestore.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/publications/EPublicationsAdminRestore.kt
@@ -34,7 +34,7 @@ class EPublicationsAdminRestore : RPublicationsAdminRestore(0, "", true) {
         if (apiAccount.id != 1L && publicationModeration!!.creator.id == apiAccount.id) throw ApiException(E_SELF)
         publication = ControllerPublications.getPublication(((publicationModeration as PublicationModeration).moderation as ModerationBlock).publicationId, apiAccount.id)
         if (apiAccount.id != 1L && publication!!.creator.id == apiAccount.id) throw ApiException(E_SELF)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/publications/EPublicationsAdminRestoreDeepBlock.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/publications/EPublicationsAdminRestoreDeepBlock.kt
@@ -6,6 +6,7 @@ import com.dzen.campfire.api.models.publications.Publication
 import com.dzen.campfire.api.models.publications.history.HistoryAdminNotDeepBlock
 import com.dzen.campfire.api.requests.publications.RPublicationsAdminRestoreDeepBlock
 import com.dzen.campfire.server.controllers.ControllerFandom
+import com.dzen.campfire.server.controllers.ControllerModeration
 import com.dzen.campfire.server.controllers.ControllerNotifications
 import com.dzen.campfire.server.controllers.ControllerPublications
 import com.dzen.campfire.server.controllers.ControllerPublicationsHistory
@@ -23,6 +24,7 @@ class EPublicationsAdminRestoreDeepBlock : RPublicationsAdminRestoreDeepBlock(0,
     override fun check() {
         ControllerFandom.checkCan(apiAccount, API.LVL_PROTOADMIN)
         publication = ControllerPublications.getPublication(publicationId, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerChangeName.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerChangeName.kt
@@ -20,7 +20,7 @@ class ERubricsModerChangeName : RRubricsModerChangeName(0, "", "") {
     @Throws(ApiException::class)
     override fun check() {
         newName = ControllerCensor.cens(newName)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         val rubricX = ControllerRubrics.getRubric(rubricId)
         if (rubricX == null || rubricX.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
         rubric = rubricX

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerChangeOwner.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerChangeOwner.kt
@@ -23,7 +23,7 @@ class ERubricsModerChangeOwner : RRubricsModerChangeOwner(0, 0, "") {
 
     @Throws(ApiException::class)
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         val rubricX = ControllerRubrics.getRubric(rubricId)
         if (rubricX == null || rubricX.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
         rubric = rubricX

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerCreate.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerCreate.kt
@@ -20,7 +20,7 @@ class ERubricsModerCreate : RRubricsModerCreate(0, 0, "", 0, "") {
     @Throws(ApiException::class)
     override fun check() {
         name = ControllerCensor.cens(name)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         ControllerFandom.checkCan(apiAccount, fandomId, languageId, API.LVL_MODERATOR_RUBRIC)
         val fandomX = ControllerFandom.getFandom(fandomId)
         if (fandomX == null || fandomX.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsModerRemove.kt
@@ -19,7 +19,7 @@ class ERubricsModerRemove : RRubricsModerRemove(0, "") {
 
     @Throws(ApiException::class)
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         val rubricX = ControllerRubrics.getRubric(rubricId)
         if (rubricX == null || rubricX.status != API.STATUS_PUBLIC) throw ApiException(API.ERROR_ACCESS)
         rubric = rubricX

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsMoveFandom.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/rubrics/ERubricsMoveFandom.kt
@@ -7,6 +7,7 @@ import com.dzen.campfire.api.models.publications.moderations.rubrics.ModerationR
 import com.dzen.campfire.api.requests.rubrics.RRubricsMoveFandom
 import com.dzen.campfire.api.tools.ApiException
 import com.dzen.campfire.server.controllers.ControllerFandom
+import com.dzen.campfire.server.controllers.ControllerModeration
 import com.dzen.campfire.server.controllers.ControllerNotifications
 import com.dzen.campfire.server.controllers.ControllerPublications
 import com.dzen.campfire.server.controllers.ControllerRubrics
@@ -33,6 +34,8 @@ class ERubricsMoveFandom : RRubricsMoveFandom(0, 0, 0, "") {
             throw ApiException(API.ERROR_GONE, "Fandom does not exist")
         if (! API.isLanguageExsit(languageId))
             throw ApiException(API.ERROR_GONE, "Language does not exist")
+
+        moderatorComment = ControllerModeration.parseComment(moderatorComment, apiAccount.id)
     }
 
     override fun execute(): Response {

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsChange.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsChange.kt
@@ -27,7 +27,7 @@ class ETagsChange : RTagsChange(0, null, "", null, false) {
     override fun check() {
 
         if (removeImage && image != null) throw ApiException(E_BAD_PARAMS)
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         publication = ControllerPublications.getPublication(publicationId, apiAccount.id) as PublicationTag?
 

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsCreate.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsCreate.kt
@@ -20,7 +20,7 @@ class ETagsCreate : RTagsCreate("", "", 0, 0, 0, null) {
 
     override fun check() {
 
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
 
         if (parentId != 0L) {
             publicationParent = ControllerPublications.getPublication(parentId, apiAccount.id) as PublicationTag?

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsMove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsMove.kt
@@ -24,7 +24,7 @@ class ETagsMove : RTagsMove(0, 0, "") {
 
     @Throws(ApiException::class)
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         publication = ControllerPublications.getPublication(publicationId, apiAccount.id) as PublicationTag?
         publicationOldParent = ControllerPublications.getPublication(publication!!.parentPublicationId, apiAccount.id) as PublicationTag?
         publicationNewParent = ControllerPublications.getPublication(newCategoryId, apiAccount.id) as PublicationTag?

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsMoveCategory.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsMoveCategory.kt
@@ -20,7 +20,7 @@ class ETagsMoveCategory : RTagsMoveCategory(0, 0, "") {
 
     @Throws(ApiException::class)
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         publication = ControllerPublications.getPublication(publicationId, apiAccount.id) as PublicationTag?
         publicationOther = ControllerPublications.getPublication(beforeCategoryId, apiAccount.id) as PublicationTag?
         if (publication == null) throw ApiException(API.ERROR_GONE)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsMoveTag.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsMoveTag.kt
@@ -20,7 +20,7 @@ class ETagsMoveTag : RTagsMoveTag(0, 0, "") {
 
     @Throws(ApiException::class)
     override fun check() {
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         publication = ControllerPublications.getPublication(publicationId, apiAccount.id) as PublicationTag?
         publicationOther = ControllerPublications.getPublication(beforeTagId, apiAccount.id) as PublicationTag?
         if (publication == null) throw ApiException(API.ERROR_GONE)

--- a/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsRemove.kt
+++ b/CampfireServer/src/main/java/com/dzen/campfire/server/executors/tags/ETagsRemove.kt
@@ -24,7 +24,7 @@ class ETagsRemove : RTagsRemove("", 0) {
     @Throws(ApiException::class)
     override fun check() {
 
-        ControllerModeration.parseComment(comment, apiAccount.id)
+        comment = ControllerModeration.parseComment(comment, apiAccount.id)
         publication = ControllerPublications.getPublication(publicationId, apiAccount.id) as PublicationTag?
 
         if (publication == null) throw ApiException(API.ERROR_GONE)

--- a/DevSupJava/src/main/java/com/sup/dev/java/tools/ToolsDate.kt
+++ b/DevSupJava/src/main/java/com/sup/dev/java/tools/ToolsDate.kt
@@ -1,223 +1,96 @@
 package com.sup.dev.java.tools
 
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
 
 object ToolsDate {
-
-    private val format1 = "dd MMM yyyy HH:mm"
-    private val format2 = "dd MMM HH:mm"
-    private val format3 = "HH:mm"
+    private const val format_full = "EEE, dd.MM.yyyy HH:mm:ss"
+    private const val format_short1 = "d MMM y HH:mm"
+    private const val format_short2 = "d MMM HH:mm"
+    private const val format_short3 = "HH:mm"
 
     val currentDayOfWeek: Int
         get() {
-            var i = GregorianCalendar.getInstance().get(Calendar.DAY_OF_WEEK) - 2
-            if (i == -1) i = 6
-            return i
+            // Idk how this works
+            var day = Calendar.getInstance().get(Calendar.DAY_OF_WEEK) - 2
+            if (day == -1) day = 6
+            return day
         }
 
+    fun dateToString(time: Long, compact: Boolean = true): String {
+        val date = Date(time)
+        if (!compact) {
+            val formatter = SimpleDateFormat(format_short1, Locale.getDefault())
+            return formatter.format(date)
+        }
 
-    val currentHourseOfDay: Int
-        get() = GregorianCalendar.getInstance().get(Calendar.HOUR_OF_DAY)
-    val currentMinutesOfHourse: Int
-        get() = GregorianCalendar.getInstance().get(Calendar.MINUTE)
+        val calendarNow = Calendar.getInstance()
+        val calendar = Calendar.getInstance()
+        calendar.setTime(date)
 
-    val nowDay: Calendar
-        get() = GregorianCalendar.getInstance()
+        val formatter: SimpleDateFormat
+        if (calendarNow.get(Calendar.YEAR) != calendar.get(Calendar.YEAR)) {
+            formatter = SimpleDateFormat(format_short1, Locale.getDefault())
+        } else if (calendarNow.get(Calendar.DAY_OF_YEAR) != calendar.get(Calendar.DAY_OF_YEAR)) {
+            formatter = SimpleDateFormat(format_short2, Locale.getDefault())
+        } else {
+            formatter = SimpleDateFormat(format_short3, Locale.getDefault())
+        }
 
+        return formatter.format(date)
+    }
 
-    fun getStartOfDay(): Long {
-        val calendar = GregorianCalendar.getInstance()
-        calendar.set(Calendar.SECOND, 0)
-        calendar.set(Calendar.MINUTE, 0)
+    fun dateToStringFull(time: Long): String {
+        val formatter = SimpleDateFormat(format_full, Locale.getDefault())
+        val formatted = formatter.format(Date(time))
+        val capitalized = formatted.substring(0, 1).uppercase() + formatted.substring(1)
+        return capitalized
+    }
+
+    fun getStartOfDay(date: Long? = null): Long {
+        val calendar = Calendar.getInstance()
+        if (date != null) {
+            calendar.timeInMillis = date
+        }
+
         calendar.set(Calendar.HOUR_OF_DAY, 0)
+        calendar.set(Calendar.MINUTE, 0)
+        calendar.set(Calendar.SECOND, 0)
         calendar.set(Calendar.MILLISECOND, 0)
         return calendar.timeInMillis
     }
 
     fun getStartOfMonth(): Long {
-        val calendar = GregorianCalendar.getInstance()
-        calendar.set(Calendar.HOUR_OF_DAY, 0)
-        calendar.clear(Calendar.MINUTE)
-        calendar.clear(Calendar.SECOND)
-        calendar.clear(Calendar.MILLISECOND)
+        val calendar = Calendar.getInstance()
         calendar.set(Calendar.DAY_OF_MONTH, 1)
-        return calendar.timeInMillis
-    }
-
-    fun getStartOfNextMonth(): Long {
-        val calendar = GregorianCalendar.getInstance()
         calendar.set(Calendar.HOUR_OF_DAY, 0)
-        calendar.clear(Calendar.MINUTE)
-        calendar.clear(Calendar.SECOND)
-        calendar.clear(Calendar.MILLISECOND)
-        calendar.set(Calendar.DAY_OF_MONTH, 1)
-        calendar.add(Calendar.MONTH, 1)
-        return calendar.timeInMillis
-    }
-
-    fun getLocalTime(date: Long) = date + getTimeZone()
-
-    fun getTimeZone() = Calendar.getInstance().get(Calendar.ZONE_OFFSET).toLong()
-
-    fun getTimeZoneHours() = (getTimeZone() / 1000 / 60 / 60).toInt()
-
-    fun getTimeZoneName(): String {
-        val cal = Calendar.getInstance()
-        val milliDiff = cal.get(Calendar.ZONE_OFFSET).toLong()
-        val ids = TimeZone.getAvailableIDs()
-        var name = ""
-        for (id in ids) {
-            val tz = TimeZone.getTimeZone(id)
-            if (tz.rawOffset.toLong() == milliDiff) {
-                name = id
-                break
-            }
-        }
-        return name
-    }
-
-    fun getStartOfDay(date: Long) = getStartOfDay_GlobalTimeZone(date) - getTimeZone()
-
-    fun getStartOfDay_GlobalTimeZone(date: Long):Long{
-        val calendar = GregorianCalendar.getInstance()
-        calendar.timeInMillis = date
-        calendar.set(Calendar.SECOND, 0)
         calendar.set(Calendar.MINUTE, 0)
-        calendar.set(Calendar.HOUR_OF_DAY, 0)
+        calendar.set(Calendar.SECOND, 0)
         calendar.set(Calendar.MILLISECOND, 0)
         return calendar.timeInMillis
     }
 
-    fun format_yyyy_MM_dd(date: Long): String {
-        return SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(date))
+    fun getCurrentMillisecondsOfDay() = System.currentTimeMillis() - getStartOfDay()
+
+    fun getCurrentMinutesOfDay(): Long {
+        val calendar = Calendar.getInstance()
+        return calendar.get(Calendar.HOUR_OF_DAY) * 60L + calendar.get(Calendar.MINUTE)
     }
 
-    fun format_kk_mm_ss(date: Long): String {
-        return SimpleDateFormat("kk:mm:ss", Locale.getDefault()).format(Date(date))
+    fun getCurrentDayOfMonth() = Calendar.getInstance().get(Calendar.DAY_OF_MONTH).toLong()
+
+    fun timeToString(hours: Int, minutes: Int) = hours.toString() +
+        ":" + (if (minutes < 10) "0" else "") + minutes.toString()
+
+    fun timeToString(time: Long): String {
+        val hours = time / (1000 * 60 * 60)
+        val minutes = (time / (1000 * 60)) % 60
+        val seconds = (time / 1000) % 60
+
+        return hours.toString() +
+            ":" + minutes.toString().padStart(2, '0') +
+            ":" + seconds.toString().padStart(2, '0')
     }
-
-    fun format_hh_mm_ss(date: Long): String {
-        return format_hh_mm_ss(Date(date))
-    }
-
-    fun format_hh_mm_ss(date: Date): String {
-        return SimpleDateFormat("hh:mm:ss", Locale.getDefault()).format(date)
-    }
-
-    fun format_HH_mm_ss(date: Date): String {
-        return SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(date)
-    }
-
-    fun format_dd_MM_yyyy(date: Date): String {
-        return SimpleDateFormat("dd.MM.yyyy", Locale.getDefault()).format(date)
-    }
-
-    fun timeToString(h: Int, m: Int, s: Int): String {
-        var text = ""
-
-        text += if (h < 10) "0$h" else h
-        text += ":"
-        text += if (m < 10) "0$m" else m
-        text += ":"
-        text += if (s < 10) "0$s" else s
-
-
-        return text
-    }
-
-    fun timeToString(h: Int, m: Int): String {
-        var s = ""
-
-        s += if (h < 10) "0$h" else h
-        s += ":"
-        s += if (m < 10) "0$m" else m
-
-        return s
-    }
-
-    fun dayTimeToString_Ms(ms: Int) = dayTimeToString_Ms(ms.toLong())
-    fun dayTimeToString_Ms(ms: Long) = dayTimeToString_Sec(ms / 1000)
-    fun dayTimeToString_Ms_HH_MM_SS(ms: Long) = dayTimeToString_Sec_HH_MM_SS(ms / 1000)
-
-    fun dayTimeToString_Sec(sec: Int) = dayTimeToString_Sec(sec.toLong())
-    fun dayTimeToString_Sec(sec: Long) = dayTimeToString_Min(sec / 60)
-    fun dayTimeToString_Sec_HH_MM_SS(sec: Long) = timeToString(sec.toInt() / 60 / 60, (sec.toInt()%(60*60))/60, sec.toInt() % 60)
-
-    fun dayTimeToString_Min(dayTime: Int) = dayTimeToString_Min(dayTime.toLong())
-    fun dayTimeToString_Min(dayTime: Long) = timeToString(dayTime.toInt() / 60, dayTime.toInt() % 60)
-
-    fun dateToString(time: Long): String {
-        val nowDate = GregorianCalendar.getInstance()
-        val date = GregorianCalendar.getInstance()
-
-        nowDate.timeInMillis = System.currentTimeMillis()
-        date.timeInMillis = time
-        val formatter: SimpleDateFormat
-        if (nowDate.get(Calendar.YEAR) != date.get(Calendar.YEAR)) {
-            formatter = SimpleDateFormat(format1)
-        } else {
-            if (nowDate.get(Calendar.MONTH) != date.get(Calendar.MONTH) || nowDate.get(Calendar.DAY_OF_MONTH) != date.get(Calendar.DAY_OF_MONTH)) {
-                formatter = SimpleDateFormat(format2)
-            } else {
-                formatter = SimpleDateFormat(format3)
-            }
-        }
-        return formatter.format(Date(time))
-    }
-
-    fun dateToStringFull(time: Long): String {
-        return SimpleDateFormat(format1).format(Date(time))
-    }
-
-    fun getCurrentMonthOfYear() = GregorianCalendar.getInstance().get(Calendar.MONTH) + 1
-
-    fun getCurrentMonthOfYear(date: Long): Int {
-        val instance = GregorianCalendar.getInstance()
-        instance.timeInMillis = date
-        return instance.get(Calendar.MONTH)
-    }
-
-    fun getCurrentDayOfMonth() = GregorianCalendar.getInstance().get(Calendar.DAY_OF_MONTH)
-
-    fun getCurrentDayOfMonth(date: Long): Int {
-        val instance = GregorianCalendar.getInstance()
-        instance.timeInMillis = date
-        return instance.get(Calendar.DAY_OF_MONTH)
-    }
-
-    fun getCurrentHourOfDay() = getCurrentMinutesOfDay() / 60
-
-    fun getCurrentMinutesOfDay() = getCurrentSecondsOfDay() / 60
-
-    fun getCurrentMinutesOfHour() = getCurrentMinutesOfDay() % 60
-
-    fun getCurrentSecondsOfDay() = getCurrentMillisecondsOfDay() / 1000
-
-    fun getCurrentSecondsOfHour() = getCurrentSecondsOfDay() % (60 * 60)
-
-    fun getCurrentSecondsOfMinute() = getCurrentSecondsOfDay() % 60
-
-    fun getCurrentMillisecondsOfDay(): Long {
-        val calendar = GregorianCalendar.getInstance()
-        val minutes = calendar.get(Calendar.MINUTE)
-        val hours = calendar.get(Calendar.HOUR_OF_DAY)
-        val seconds = calendar.get(Calendar.SECOND)
-        val milliseconds = calendar.get(Calendar.MILLISECOND)
-        return ((hours * 60L + minutes) * 60 + seconds) * 1000 + milliseconds
-    }
-
-    fun getLocalDateTime(serverDateTime: String, serverTimezoneId: String = "UTC", format: String = "yyyy-MM-dd HH:mm:ss"): String {
-        return try {
-            val dateFormat = SimpleDateFormat(format)
-            dateFormat.timeZone = TimeZone.getTimeZone(serverTimezoneId) // timezone of server
-            val date = dateFormat.parse(serverDateTime)
-            dateFormat.timeZone = Calendar.getInstance().timeZone        // timezone of device
-            dateFormat.format(date)
-        } catch (e: Exception) {
-            serverDateTime
-        }
-    }
-
-
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
-# Bonfire
+# [Bonfire](https://play.google.com/store/apps/details?id=sh.sit.bonfire)
 
-Android app
+[![CI Status](https://github.com/timas130/bonfire/workflows/Continuous%20Integration/badge.svg)](https://github.com/timas130/bonfire/actions)
+[![EN Translation Status](https://tlp.bonfire.moe/widgets/bonfire/en/svg-badge.svg)](https://tlp.bonfire.moe/projects/bonfire/-/en)
+[![RU Translation Status](https://tlp.bonfire.moe/widgets/bonfire/ru/svg-badge.svg)](https://tlp.bonfire.moe/projects/bonfire/-/ru)
+[![UK Translation Status](https://tlp.bonfire.moe/widgets/bonfire/uk/svg-badge.svg)](https://tlp.bonfire.moe/projects/bonfire/-/uk)
+
+A social network for Android with many communities and a unique moderation system: its users can
+earn moderator privileges by completing achievements and gaining karma (likes). It has an extensive
+post editor that supports Markdown, images, GIFs, polls, etc. There are chats for each community,
+private chats between users (DMs) and private conferences.
+
+## Features
+
+* Anyone can create and curate their own community: there are wiki pages, quests, relay races and
+  rubrics to help other communities engage with it.
+* Users have full control over media: anyone can become a moderator and everyone can vote for
+  adding a new rule or feature to any community.
+* Community participation rewards: from special badges to moderation abilities depending on your
+  level and karma. You can earn exclusive privileges by creating engaging spaces!
+
+## Building the app
+
+You can build and run the app using Android Studio. [Java 17](https://jdk.java.net/archive) is
+recommended.
+
+## License
+
+This project contains components licensed differently. See [LICENSE](LICENSE) for full details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,15 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 
+# The properties below can be overriden in local.properties
+# For configuring the server edit secrets/Secrets.json
 POSTHOG_API_KEY=phc_DLL3ZwtgG3P69VbpCS8U4rhy6ZIcOlHqUc2hUFp7qoQ
-POSTHOG_HOST=https://chronicle.bonfire.moe
+
+HOST=bonfire.moe
+SERVER_POSTHOG=https://chronicle.bonfire.moe
+SERVER_ROOT=https://proxy.bonfire.moe/cf2
+SERVER_MELIOR=https://proxy.bonfire.moe/api
+SERVER_S3=https://proxy.bonfire.moe/bonfire
+
+APP_ID=sh.sit.bonfire
+APP_NAME=Bonfire

--- a/secrets_sample/Secrets.json
+++ b/secrets_sample/Secrets.json
@@ -2,35 +2,44 @@
   "bots_tokens": [
     "xxxxxx"
   ],
-  "config":{
-    "build_type":"debug",
-    "patch_prefix":"CampfireServer/build/distributions/CampfireServer/",
-    "patch_prefix_b":"CampfireServerMedia/build/distributions/CampfireServerMedia/lib/",
-    "database_login":"",
-    "database_password":"",
-    "database_name":"",
-    "database_address":"",
-    "database_media_login":"",
-    "database_media_password":"",
-    "database_media_name":"",
-    "database_media_address":"",
+  "config": {
+    "build_type": "debug",
+    "patch_prefix": "CampfireServer/build/distributions/CampfireServer/",
+    "patch_prefix_b": "CampfireServerMedia/build/distributions/CampfireServerMedia/lib/",
+    "database_login": "",
+    "database_password": "",
+    "database_name": "",
+    "database_address": "",
+    "database_media_login": "",
+    "database_media_password": "",
+    "database_media_name": "",
+    "database_media_address": "",
     "rust_address": "http://localhost:51681"
   },
-  "keys":{
-    "google_notification_key":"",
+  "api": {
+    "host": "bonfire.moe",
+    "server_root": "https://proxy.bonfire.moe/cf2",
+    "server_melior": "https://proxy.bonfire.moe/api",
+    "server_s3": "https://proxy.bonfire.moe/bonfire"
+  },
+  "keys": {
+    "google_notification_key": "",
     "google_auth": [
-      {"client_id": "", "secret": ""}
+      {
+        "client_id": "",
+        "secret": ""
+      }
     ],
-    "jks_password":"",
+    "jks_password": "",
     "hcaptcha_site_key": "10000000-ffff-ffff-ffff-000000000001",
     "hcaptcha_secret": "0x0000000000000000000000000000000000000000",
     "productlane_key": "",
     "productlane_workspace": "",
     "internal_key": "internal_key_dont_use"
   },
-  "donates":{
-    "field":"",
-    "value":""
+  "donates": {
+    "field": "",
+    "value": ""
   },
   "firebase": {
     "type": "",


### PR DESCRIPTION
* Айпи серверов, название пакета и приложения перенесены в `gradle.properties`. Их можно будет
  указать в `local.properties`. В `Secrets.json` появилось новое поле `api`
  * `appId` нужен в случае, если был задан другой айди приложения в консоли Firebase (для `google-services.json`)
* В `README.md` появилось краткое описание банки
* Убрано ограчинение на создание приветственных постов (BON-244)
* Пустые комментарии под любыми мод. действиями теперь отклоняются сервером (в том числе те,
  которые содержат только пробелы) (BON-191)
  * Теперь в любых адм. действиях можно писать русские комментарии
* Возвращён экран подписчиков фэндома (BON-107)
* Исправлены аватарки пользователей в жалобах на публикацию (BON-255)
* У отложенных постов в истории теперь показывается, до какого времени они отложены (BON-251)
* При нажатии на дату публикации комментария или поста отобразится тост с полной датой (к примеру:
  `Вт, 02.12.2025 22:56:39`) (BON-256)
  * В датах число месяца теперь отображается без лишего нуля (`02 дек.` -> `2 дек.`)
* Исправлена отправка сообщений в доп. чатах фэндома (BON-257)
* Исправлен показ публикаций в тегах (BON-258)